### PR TITLE
Feature/add browser support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('pkginfo')(module, 'version');
+module.exports.version = require('./package.json').version;
 module.exports = require('./lib/api').UpworkApi;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     {
       "name": "Maksym Novozhylov",
       "url": "https://github.com/mnovozhylov"
+    },
+    {
+      "name": "James Drew",
+      "url" : "https://github.com/jdrew1303",
+      "email" : "j.drew1303@gmail.com"
     }
   ],
   "homepage": "https://developers.upwork.com",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "dependencies": {
     "oauth": "0.9.10",
     "node-upwork": "0.0.7",
-    "qs": "~0.6.5",
-    "pkginfo": "*"
+    "qs": "~0.6.5"
   },
   "keywords": [
     "oauth",


### PR DESCRIPTION
Removed dependency on pkginfo closing issue #13. Library can now be used in the browser without error.